### PR TITLE
feat: replace deprecated secrets with env

### DIFF
--- a/squid.yaml
+++ b/squid.yaml
@@ -6,8 +6,9 @@ description: |-
 build:
 
 deploy:
-  secrets:
-    - RPC_ENDPOINT
+  env:
+    # Replace it with your secret or other string value
+    RPC_ENDPOINT: ${{ secrets.RPC_ENDPOINT }}
   addons:
     postgres:
   processor:


### PR DESCRIPTION
According to docs: https://docs.subsquid.io/cloud/reference/manifest/#secrets

We should replace  the deprecated secrets with env and it works with secrets.