### PR TITLE
Default to scale.dedicated: false

### DIFF
--- a/squid.yaml
+++ b/squid.yaml
@@ -14,3 +14,6 @@ deploy:
     cmd: [ "sqd", "process:prod" ]
   api:
     cmd: [ "sqd", "serve:prod" ]
+
+scale:
+  dedicated: false


### PR DESCRIPTION
so that we can avoid ` Scale and multi-processor options are available only for Pro plan organizations. To extend the limits, create an organization...` when user first built the template